### PR TITLE
Update README.md for dependencies installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 For Ubuntu:
 ```
 sudo apt update
-sudo apt install build-essential gcc g++ make cmake libelf-dev llvm clang libzstd1 git libjson-glib-dev
+sudo apt -y install build-essential gcc g++ make cmake libelf-dev llvm clang libzstd1 git libjson-glib-dev
 ```
 
 ## Build


### PR DESCRIPTION
The installation as per the current provided dependencies code snippet asks for 'Y' and 'N' during the installation process, however this option can skipped using '-y' for auto yes option that would require less manual intervention.

I have tested it on my Ubuntu 20.4 instance and it works as expected after adding -y flag.