### PR TITLE
Linux compiler fixes (GCC & CLANG)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,7 +399,7 @@ set(CLANG_INCLUDES
 function(build_ebpf ebpfsrc)
     add_custom_command(TARGET sysinternalsEBPF
                        PRE_BUILD
-                       COMMAND "${CLANG}" -nostdinc -isystem `gcc -print-file-name=include` ${CLANG_INCLUDES} ${CLANG_DEFINES} -O2 ${CLANG_OPTIONS} -emit-llvm -c "${CMAKE_SOURCE_DIR}/ebpfKern/${ebpfsrc}.c" -o -| "${LLC}" -march=bpf -filetype=obj -o "${ebpfsrc}.o"
+                       COMMAND "${CLANG}" -nostdinc -isystem `gcc -print-file-name=include` ${CLANG_INCLUDES} ${CLANG_DEFINES} -O2 ${CLANG_OPTIONS} -emit-llvm -fno-stack-protector -c "${CMAKE_SOURCE_DIR}/ebpfKern/${ebpfsrc}.c" -o -| "${LLC}" -march=bpf -filetype=obj -o "${ebpfsrc}.o"
                        COMMENT "Building EBPF object ${ebpfsrc}.o"
                        DEPENDS ebpfKern/${ebpfsrc}.c ${EBPF_DEPENDS}
                        )

--- a/discoverOffsets.c
+++ b/discoverOffsets.c
@@ -172,7 +172,7 @@ void memDumpCloseAll()
 //--------------------------------------------------------------------
 bool isPointer(uint64_t ptr)
 {
-    if (labs(ptr - memAddrs[task]) < MAX_POINTER_DIFF) {
+    if (ptr < (MAX_POINTER_DIFF + memAddrs[task])) {
         return true;
     } else {
         return false;
@@ -189,7 +189,7 @@ bool isPointer(uint64_t ptr)
 //--------------------------------------------------------------------
 bool near(uint64_t a, uint64_t b, uint64_t range)
 {
-    if (labs(a - b) <= range) {
+    if (a <= (range + b)) {
         return true;
     } else {
         return false;


### PR DESCRIPTION
Modify the eBPF programlet compilation to add `-fno-stack-protector` similar to https://github.com/Sysinternals/SysmonForLinux/pull/42

Additionally, the compiler warnings identified two calls to `labs(...)` that would always evaluate to `true` due to them operating on an `unsigned` value. I modified the less-than comparison to move the subtracted value from the left-hand side to be an added value to the right-hand side, and removed the `labs(...)` calls.