### PR TITLE
License of libbpf is dual-licensed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Use 'find' on the package directory to locate it manually.
 
 ## License
 SysinternalsEBPF is licensed under LGPL2.1.
-SysinternalsEBPF includes libbpf, which is licensed under LGPL2.1.
+SysinternalsEBPF includes libbpf, which is dual-licensed under BSD 2-clause
+license and LGPL2.1.
 Libbpf can be located at https://github.com/libbpf/libbpf
 The SysinternalsEBPF library of eBPF code is licensed under GPL2.
 


### PR DESCRIPTION
As libpdf writes on its own GitHub side
https://github.com/libbpf/libbpf

> This work is dual-licensed under BSD 2-clause license and GNU LGPL v2.1 license. You can choose between one of them if you use this work.
> 
> `SPDX-License-Identifier: BSD-2-Clause OR LGPL-2.1`

But SysinternalsEBPF have had only mentioned the LGPL.